### PR TITLE
ヘッダー内のメニュー機能を追加

### DIFF
--- a/src/jsx/views/components/blocks/menu/Menu.jsx
+++ b/src/jsx/views/components/blocks/menu/Menu.jsx
@@ -1,0 +1,55 @@
+import styled from "styled-components";
+import { Link } from "react-router-dom";
+import MenuData from '../menu/MenuData';
+
+const Menu = () => {
+  return (
+    <SidebarContainer>
+      <SidebarLists>
+        {MenuData.map((value, key) => {
+          return (
+            <SidebarList key={key}>
+              <Link to={value.link}>
+                <ListIcon>{value.icon}</ListIcon>
+                <ListTitle>{value.title}</ListTitle>
+              </Link>
+            </SidebarList>
+          );
+        })};
+      </SidebarLists>
+    </SidebarContainer>
+  );
+};
+
+const SidebarContainer = styled.div`
+  height: 100%;
+  width: 20%;
+  min-width: 300px;
+  background-color: #3b627a;
+`;
+
+const SidebarLists = styled.ul`
+  height: auto;
+  width: 100%
+  list-style: none;
+`;
+
+const SidebarList = styled.li`
+  width: 100%;
+  &:hover {
+    cursor: pointer;
+    background-color: lightgreen;
+  }
+`;
+
+const ListIcon = styled.div`
+  height: 60px;
+  color: white;
+`;
+
+const ListTitle = styled.div`
+  height: 60px;
+  color: white;
+`;
+
+export default Menu;

--- a/src/jsx/views/components/blocks/menu/MenuData.jsx
+++ b/src/jsx/views/components/blocks/menu/MenuData.jsx
@@ -1,0 +1,23 @@
+import SearchIcon from '@mui/icons-material/Search';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
+import DirectionsWalkIcon from '@mui/icons-material/DirectionsWalk';
+
+const MenuData = [
+  {
+    title: "検索",
+    icon: <SearchIcon />,
+    link: "search",
+  },
+  {
+    title: "パスワードリセット",
+    icon: <RestartAltIcon/>,
+    link: "pwreset",
+  },
+  {
+    title: "退会",
+    icon: <DirectionsWalkIcon/>,
+    link: "withdrawalconfirmation",
+  },
+];
+
+export default MenuData;


### PR DESCRIPTION
ヘッダー内のメニューロゴをクリックすると右からメニュー一覧が表示される機能を追加

▼Issues
https://github.com/Shin-Goz-Maeda/related-item-client/issues/14