### PR TITLE
#22 メインページでアイテムURLを画像として表示させる処理を追加

### DIFF
--- a/src/jsx/views/components/blocks/mainItemContainer/ItemContainer.jsx
+++ b/src/jsx/views/components/blocks/mainItemContainer/ItemContainer.jsx
@@ -1,0 +1,27 @@
+import ItemImage from './itemImage/ItemImage';
+import ItemInfoContainer from './itemInfoContainer/ItemInfoContainer';
+import styled from 'styled-components';
+
+const ItemContainer = (props) => {
+  const { itemName, brand, itemUrl, itemCategory } = props;
+
+  return (
+    <ItemsContainer className='itemContainer'>
+      <ItemImage itemUrl={itemUrl}/>
+      <ItemInfoContainer
+        itemName={itemName}
+        brand={brand}
+        itemCategory={itemCategory}
+      />
+    </ItemsContainer>
+  );
+};
+
+const ItemsContainer = styled.div`
+  width: 300px;
+  height: 350px;
+  margin: 20px;
+  border: 3px solid blue;
+`;
+
+export default ItemContainer;

--- a/src/jsx/views/components/blocks/mainItemContainer/itemImage/ItemImage.jsx
+++ b/src/jsx/views/components/blocks/mainItemContainer/itemImage/ItemImage.jsx
@@ -1,0 +1,27 @@
+import styled from 'styled-components';
+
+const ItemImage = (props) => {
+  const { itemUrl } = props;
+
+  return (
+    <ItemsImage id='itemImage' className='itemImage'>
+      <Img src={itemUrl} />
+    </ItemsImage>
+  );
+};
+
+const ItemsImage = styled.div`
+  width: 95%;
+  height: 65%;
+  margin-top: 5px;
+  margin-right: auto;
+  margin-left: auto;
+  border: 2px solid red;
+`;
+
+const Img = styled.img`
+  width: 100%;
+  height: 100%;
+`;
+
+export default ItemImage;

--- a/src/jsx/views/components/blocks/mainItemContainer/itemInfoContainer/ItemInfoContainer.jsx
+++ b/src/jsx/views/components/blocks/mainItemContainer/itemInfoContainer/ItemInfoContainer.jsx
@@ -1,0 +1,34 @@
+import styled from "styled-components";
+
+const ItemInfoContainer = (props) => {
+  const { itemName, brand, itemCategory } = props;
+
+  return (
+    <ItemInfoContent id='itemInfo' className='itemInfo'>
+      <ItemInfoLists>
+        <ItemInfoList id='brand' className='item'>{brand}</ItemInfoList>
+        <ItemInfoList id='itemName' className='item'>{itemName}</ItemInfoList>
+        <ItemInfoList id='itemCategory' className='item'>{itemCategory}</ItemInfoList>
+      </ItemInfoLists>
+    </ItemInfoContent>
+  );
+};
+
+const ItemInfoContent = styled.div`
+  width: 95%;
+  height: 30%;
+  border: 2px solid red;
+  margin-bottom: 5px;
+  margin-right: auto;
+  margin-left: auto;
+`;
+
+const ItemInfoLists = styled.ul`
+  padding: 0;
+`;
+
+const ItemInfoList = styled.li`
+  list-style: none;
+`;
+
+export default ItemInfoContainer;


### PR DESCRIPTION
DBから取得した画像のURLを表示させるエリアを作成する。
- エンドポイント
  ・ /getImage
-  DBから取得する画像の詳細
  ・アイテムのURLを取得する
  ・ DB (itemUrl)
- 表示方法は、各URLを均等に画面で表示させる。

▼Issues
https://github.com/Shin-Goz-Maeda/related-item-client/issues/22