### PR TITLE
#24 アイテムページでDBから取得した画像を表示させる機能を追加

### DIFF
--- a/src/jsx/views/components/blocks/itemItemContainer/instagramInfo/instagramImg/InstagramImg.jsx
+++ b/src/jsx/views/components/blocks/itemItemContainer/instagramInfo/instagramImg/InstagramImg.jsx
@@ -1,0 +1,21 @@
+import styled from "styled-components";
+
+const InstagramImg = (props) => {
+  const { instagramEmbedCode } = props;
+  console.log(instagramEmbedCode);
+
+  return (
+    <InstagramImgContainer
+      dangerouslySetInnerHTML={{ __html: instagramEmbedCode}}
+    >
+    </InstagramImgContainer>
+  );
+};
+
+const InstagramImgContainer = styled.div`
+  width: 100%;
+  height: 100%;
+`;
+
+
+export default InstagramImg;

--- a/src/jsx/views/components/blocks/itemItemContainer/itemInfo/ItemInfo.jsx
+++ b/src/jsx/views/components/blocks/itemItemContainer/itemInfo/ItemInfo.jsx
@@ -2,11 +2,11 @@ import ItemImg from './itemImg/ItemImg';
 import ItemDetailInformation from './itemDetailInfomation/ItemDetailInfomation';
 
 const ItemInfo = (props) => {
-  const {  itemPicUrl, itemName, brand, itemInfo, itemCategory } = props;
+  const { itemImgUrl, itemName, brand, itemInfo, itemCategory } = props;
 
   return (
     <>
-      <ItemImg itemPicUrl={itemPicUrl} />
+      <ItemImg itemImgUrl={itemImgUrl} />
       <ItemDetailInformation
         itemName={itemName}
         brand={brand}

--- a/src/jsx/views/components/blocks/itemItemContainer/itemInfo/ItemInfo.jsx
+++ b/src/jsx/views/components/blocks/itemItemContainer/itemInfo/ItemInfo.jsx
@@ -1,0 +1,20 @@
+import ItemImg from './itemImg/ItemImg';
+import ItemDetailInformation from './itemDetailInfomation/ItemDetailInfomation';
+
+const ItemInfo = (props) => {
+  const {  itemPicUrl, itemName, brand, itemInfo, itemCategory } = props;
+
+  return (
+    <>
+      <ItemImg itemPicUrl={itemPicUrl} />
+      <ItemDetailInformation
+        itemName={itemName}
+        brand={brand}
+        itemCategory={itemCategory}
+        itemInfo={itemInfo}
+      />
+    </>
+  );
+};
+
+export default ItemInfo;

--- a/src/jsx/views/components/blocks/itemItemContainer/itemInfo/itemDetailInfomation/ItemDetailInfomation.jsx
+++ b/src/jsx/views/components/blocks/itemItemContainer/itemInfo/itemDetailInfomation/ItemDetailInfomation.jsx
@@ -1,0 +1,40 @@
+import styled from "styled-components";
+
+const ItemDetailInformation = (props) => {
+  const { itemName, brand, itemInfo, itemCategory } = props;
+
+  return (
+    <ItemInfoContainer>
+      <ItemInfoLists>
+        <ItemInfoList>
+          {itemName}
+        </ItemInfoList>
+        <ItemInfoList>
+          {brand}
+        </ItemInfoList>
+        <ItemInfoList>
+          {itemCategory}
+        </ItemInfoList>
+        <ItemInfoList>
+          {itemInfo}
+        </ItemInfoList>
+      </ItemInfoLists>
+    </ItemInfoContainer>
+  );
+};
+
+const ItemInfoContainer = styled.div`
+  width: 50%;
+  height: 50%;
+  border: 1px solid blue;
+  margin: 0 auto;
+  overflow-y: scroll;
+`;
+
+const ItemInfoLists = styled.ul`
+  list-style: none;
+`;
+
+const ItemInfoList = styled.li``;
+
+export default ItemDetailInformation;

--- a/src/jsx/views/components/blocks/itemItemContainer/itemInfo/itemImg/ItemImg.jsx
+++ b/src/jsx/views/components/blocks/itemItemContainer/itemInfo/itemImg/ItemImg.jsx
@@ -1,11 +1,11 @@
 import styled from "styled-components";
 
 const ItemImg = (props) => {
-  const { itemPicUrl } = props;
+  const { itemImgUrl } = props;
 
   return (
     <ItemImgContainer>
-      <ItemDisPlayImg src={itemPicUrl}></ItemDisPlayImg>
+      <ItemDisplayImg src={itemImgUrl}></ItemDisplayImg>
     </ItemImgContainer>
   );
 };
@@ -17,7 +17,7 @@ const ItemImgContainer = styled.div`
   border: 1px solid red;
 `;
 
-const ItemDisPlayImg = styled.img`
+const ItemDisplayImg = styled.img`
   width: 100%;
   height: 100%;
 `;

--- a/src/jsx/views/components/blocks/itemItemContainer/itemInfo/itemImg/ItemImg.jsx
+++ b/src/jsx/views/components/blocks/itemItemContainer/itemInfo/itemImg/ItemImg.jsx
@@ -1,0 +1,25 @@
+import styled from "styled-components";
+
+const ItemImg = (props) => {
+  const { itemPicUrl } = props;
+
+  return (
+    <ItemImgContainer>
+      <ItemDisPlayImg src={itemPicUrl}></ItemDisPlayImg>
+    </ItemImgContainer>
+  );
+};
+
+const ItemImgContainer = styled.div`
+  width: 50%;
+  height: 50%;
+  margin: 0 auto;
+  border: 1px solid red;
+`;
+
+const ItemDisPlayImg = styled.img`
+  width: 100%;
+  height: 100%;
+`;
+
+export default ItemImg;


### PR DESCRIPTION
アイテムページでDBから取得した画像を単体で表示させる機能を追加する。
・エンドポイント
- /getImage
・DBから取得するデータの詳細
- テーブル名：ItemInfo
- カラム名：itemUrl
- データ種類：Url

▼Issues
https://github.com/Shin-Goz-Maeda/related-item-client/issues/24